### PR TITLE
fix: confusion of minus symbol

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -60,7 +60,7 @@ symbols = {
 def format(text):
     return regex.findall(
         # Locate a number or
-        "([-]?[0-9]*[.]?[0-9]+|" +
+        "((?<![0-9])[-]?[0-9]*[.]?[0-9]+|" +
 
         # a symbol or,
         "[><!=+\-*/^\\\\%]|" +


### PR DESCRIPTION
Fix the following bug:

```python
>> 5-3
5-3
```

The error is caused by matching the `-` of subtraction to the `-` of the negative number sign during regex matching. 

fix #3 